### PR TITLE
Minor fixes in conjunction with migration from previous version

### DIFF
--- a/src/Network/PagerDuty/Integration.hs
+++ b/src/Network/PagerDuty/Integration.hs
@@ -231,18 +231,19 @@ instance ToJSON Event where
 -- or ongoing problem. When PagerDuty receives a trigger event, it will either open
 -- a new incident, or add a new trigger log entry to an existing incident,
 -- depending on the provided incident_key.
-trigger :: ServiceKey  -- ^ 'serviceKey'
-        -> IncidentKey -- ^ 'incidentKey'
-        -> Text        -- ^ 'description'
+trigger :: ServiceKey   -- ^ 'serviceKey'
+        -> IncidentKey  -- ^ 'incidentKey'
+        -> Text         -- ^ 'description'
+        -> Maybe Object -- ^ 'details'
         -> Event
-trigger k i d =
+trigger k i d t =
     Trigger Trigger'
         { _tServiceKey'  = k
         , _tDescription' = d
         , _tIncidentKey' = i
         , _tClient'      = Nothing
         , _tClientUrl'   = Nothing
-        , _tDetails'     = Nothing
+        , _tDetails'     = t
         }
 
 -- | Acknowledge events cause the referenced incident to enter the acknowledged

--- a/src/Network/PagerDuty/Integration.hs
+++ b/src/Network/PagerDuty/Integration.hs
@@ -231,19 +231,18 @@ instance ToJSON Event where
 -- or ongoing problem. When PagerDuty receives a trigger event, it will either open
 -- a new incident, or add a new trigger log entry to an existing incident,
 -- depending on the provided incident_key.
-trigger :: ServiceKey   -- ^ 'serviceKey'
-        -> IncidentKey  -- ^ 'incidentKey'
-        -> Text         -- ^ 'description'
-        -> Maybe Object -- ^ 'details'
+trigger :: ServiceKey  -- ^ 'serviceKey'
+        -> IncidentKey -- ^ 'incidentKey'
+        -> Text        -- ^ 'description'
         -> Event
-trigger k i d t =
+trigger k i d =
     Trigger Trigger'
         { _tServiceKey'  = k
         , _tDescription' = d
         , _tIncidentKey' = i
         , _tClient'      = Nothing
         , _tClientUrl'   = Nothing
-        , _tDetails'     = t
+        , _tDetails'     = Nothing
         }
 
 -- | Acknowledge events cause the referenced incident to enter the acknowledged

--- a/src/Network/PagerDuty/Integration.hs
+++ b/src/Network/PagerDuty/Integration.hs
@@ -292,6 +292,7 @@ submitWith :: MonadIO m
            -> Event
            -> m (Either Error Response)
 submitWith m l e = request m l e $
-    def { Client.host = "events.pagerduty.com"
-        , Client.path = "/generic/2010-04-15/create_event.json"
+    def { Client.host   = "events.pagerduty.com"
+        , Client.path   = "/generic/2010-04-15/create_event.json"
+        , Client.method = "POST"
         }


### PR DESCRIPTION
* Events are submitted to PagerDuty using `POST`.
* Allow triggering events with details.