### PR TITLE
Needs GHC >= 7.8 due to PatternSynonyms

### DIFF
--- a/pagerduty.cabal
+++ b/pagerduty.cabal
@@ -72,7 +72,7 @@ library
 
     build-depends:
         aeson                 >= 0.8
-      , base                  >= 4.5      && < 5
+      , base                  >= 4.7      && < 5
       , bifunctors            >= 4.1
       , bytestring            >= 0.9
       , bytestring-conversion >= 0.2.1


### PR DESCRIPTION
I have revised existing versions (http://hackage.haskell.org/package/pagerduty/revisions/) so a new release is only needed if you want backwards compatibility .
